### PR TITLE
Add general instructions prompt

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -37,12 +37,13 @@ Options:
 Hints:
 
 - Interactive mode is the most useful. It will ask you questions and guide you through the upgrade process.
+- If running in interactive mode, Flame will ask you for a general prompt that will be used for every file to be upgraded. This is a flexible tool; for example, you can mention that you already attempted the upgrade and some files may have been upgraded already, and instruct it to tell you if it finds any issues.
 - If a file has moved, we are not currently able to find it nor move it for you. You'll need to move it manually or upgrade moved files manually. In the future, we will add ways to find those files either manually or automatically.
 - If you've customized some files extensively, you may need to manually apply the changes. Over time, Flame AI will get better at handling these cases.
 
 ## EXPERIMENTAL: Interactive Code Editing and Authoring Mode
 
-The interactive mode is one of Flame's most exciting features, but it's still **very much a work in progress.** It allows you to chat with the AI, load files, list files, and make modifications to code using plain English.
+The interactive code editing mode is one of Flame's most exciting features, but it's still **very much a work in progress.** It allows you to chat with the AI, load files, list files, and make modifications to code using plain English.
 
 To start the interactive mode, run `flame experimental interactive`. The current directory will be where you will be working. You can also specify a directory to work in by running `flame experimental interactive <directory>`.
 

--- a/src/commands/upgrade/react-native.ts
+++ b/src/commands/upgrade/react-native.ts
@@ -23,7 +23,7 @@ const command: GluegunCommand = {
     const { print, filesystem, parameters } = toolbox
     const options = parameters.options as CLIOptions
     const { colors } = print
-    const { red, cyan, white, bold } = colors
+    const { red, cyan, white, bold, gray } = colors
 
     checkOpenAIKey()
 
@@ -52,7 +52,7 @@ const command: GluegunCommand = {
     if (!currentVersion || !targetVersion) {
       return stop(
         '🙈',
-        `Could not determine current or target version. Please make sure you are in a React Native project folder and try again.`
+        `Could not determine current or target version. Please make sure you are in a React Native project folder and try again.`,
       )
     }
 
@@ -93,12 +93,27 @@ const command: GluegunCommand = {
     hr()
     br()
 
+    // Ask them for a persistant prompt that will be used for all files
+    let generalPrompt = ''
+    if (options.interactive) {
+      const { prompt } = await toolbox.prompt.ask({
+        type: 'input',
+        name: 'prompt',
+        message: `Do you have any general instructions for me for this upgrade?\n  ${gray(
+          `(optional -- leave blank if not)`,
+        )}\n`,
+        initial: '',
+      })
+      generalPrompt = prompt
+      br()
+    }
+
     print.info(bold(white(`Starting ${cyan('React Native')} upgrade using ${red(bold('Flame AI'))}\n`)))
 
     for (const fileData of files) {
       if (isFileIgnored({ ignoreFiles, only: options.only, fileData })) continue
 
-      const result = await upgradeFile({ fileData, options, currentVersion, targetVersion })
+      const result = await upgradeFile({ fileData, options, currentVersion, targetVersion, generalPrompt })
 
       br()
 


### PR DESCRIPTION
This allows you to specify a custom general prompt that applies to _every_ file that is upgraded.

This is a very flexible tool; it allows you to give it context that will help it upgrade more accurately. For example, maybe you've already attempted the upgrade, and can give it the context:

> I've already attempted this upgrade, so some of these files will appear to be upgraded already. However, I want you to examine them and let me know if there are any issues, or make the changes yourself if they're obvious enough.

You could do other things as well; this is just an example that comes readily to mind.

<img width="957" alt="CleanShot 2023-09-16 at 10 31 53@2x" src="https://github.com/infinitered/flame/assets/1479215/57e2e7c6-942f-4b6f-8582-317460cfc45d">
